### PR TITLE
fix: flash message not being cleared when using custom session

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ const session = createCookieSessionStorage({
   },
 });
 
-export const { 
-  useToast, 
+export const {
+  getToast,
   redirectWithToast, 
   redirectWithSuccess, 
   redirectWithError, 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,12 +40,6 @@ export function setToastCookieOptions(options: ToastCookieOptions) {
   );
 }
 
-function getSessionFromRequest(request: Request, customSession?: SessionStorage) {
-  const cookie = request.headers.get("Cookie");
-  const sessionToUse = customSession ? customSession : sessionStorage;
-  return sessionToUse.getSession(cookie);
-}
-
 async function flashMessage(
   flash: FlashSessionValues,
   headers?: ResponseInit["headers"],
@@ -122,11 +116,13 @@ export async function getToast(
   request: Request,
   customSession?: SessionStorage,
 ): Promise<{ toast: ToastMessage | undefined; headers: Headers }> {
-  const session = await getSessionFromRequest(request, customSession);
+  const sessionToUse = customSession ? customSession : sessionStorage;
+  const cookie = request.headers.get("Cookie");
+  const session = await sessionToUse.getSession(cookie);
   const result = flashSessionValuesSchema.safeParse(session.get(FLASH_SESSION));
   const flash = result.success ? result.data : undefined;
   const headers = new Headers({
-    "Set-Cookie": await sessionStorage.commitSession(session),
+    "Set-Cookie": await sessionToUse.commitSession(session),
   });
   const toast = flash?.toast;
   return { toast, headers };


### PR DESCRIPTION
# Description

When using custom session, the toast message is not being cleared from the right session in `getToast`. This is causing the toast message in the UI to be displayed after every page refresh.
This PR fixes it by checking which session to use in a similar way as in `flashMessage`.

Fixes #24 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

A reproducible repo was created to demonstrate the issue: https://github.com/michelmattos/remix-toast-with-custom-session

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules