### PR TITLE
feat: add optional duration to toast messages

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const toastMessageSchema = z.object({
   message: z.string(),
   description: z.string().optional(),
+  duration: z.number().int().positive().optional(),
   type: z.custom<"info" | "success" | "error" | "warning">(),
 });
 


### PR DESCRIPTION
# Description

Being able to specify a custom duration for messages that are longer vs shorter helps ensure the toast is shown for as long as it needs to be. 

Implements #27 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules